### PR TITLE
boolean for treatment indicator

### DIFF
--- a/Project 7 Template.Rmd
+++ b/Project 7 Template.Rmd
@@ -390,11 +390,13 @@ So we need a few thingfs for a Staggered Adoption Synthetic Control:
 - `uninsured_rate`: rate of insured folks per state
 - `treatsm`: whether or not the state got the treatment 
 
+
 ```{r}
 medicaid_expclean <- medicaid_expansion %>%
   mutate(dateadopt =as.numeric(as.character(as.Date(Date_Adopted,format="%Y/%m/%d"),format = "%Y"))) %>%
-  mutate(treatsm = ifelse(State !="" & dateadopt >= year, 1, 0)) %>%
-  mutate(dateadopt = ifelse(is.na(dateadopt), 0, dateadopt))
+  mutate(treatsm = 1 * (year >= dateadopt))
+  #mutate(treatsm = ifelse(State !="" & dateadopt >= year, 1, 0)) %>%
+  #mutate(dateadopt = ifelse(is.na(dateadopt), 0, dateadopt))
   
 #was it treated that year onward 
 


### PR DESCRIPTION
I realized we were flipping the logic for creating the indicator - it should be a 1 if year >= dateadopt, not the other way around. It looks like this works!